### PR TITLE
add per_user setting for per user enablement of features

### DIFF
--- a/config/features.yml
+++ b/config/features.yml
@@ -4,6 +4,8 @@ defaults: &defaults
   feature3: false
   feature4: true
   feature4a: true
+  feature6: per_user
+  feature7: per_user
 
 development:
   <<: *defaults

--- a/lib/abstract_feature_branch.rb
+++ b/lib/abstract_feature_branch.rb
@@ -150,7 +150,13 @@ module AbstractFeatureBranch
     end
 
     def booleanize_values(hash)
-      Hash[hash.map {|k, v| [k, v.to_s.downcase == 'true']}]
+      hash_values = hash.map do |k, v|
+        normalized_value = v.to_s.downcase
+        boolean_value = normalized_value == 'true'
+        new_value = normalized_value == 'per_user' ? 'per_user' : boolean_value
+        [k, new_value]
+      end
+      Hash[hash_values]
     end
 
     def downcase_keys(hash)

--- a/lib/ext/feature_branch.rb
+++ b/lib/ext/feature_branch.rb
@@ -9,8 +9,12 @@ class Object
   raise 'Abstract feature branch conflicts with another Ruby library' if respond_to?(:feature_enabled?)
   def self.feature_enabled?(feature_name, user_id = nil)
     normalized_feature_name = feature_name.to_s.downcase
-    AbstractFeatureBranch.application_features[normalized_feature_name] &&
-      (user_id.nil? || AbstractFeatureBranch.user_features_storage.sismember("#{AbstractFeatureBranch::ENV_FEATURE_PREFIX}#{normalized_feature_name}", user_id))
+
+    value = AbstractFeatureBranch.application_features[normalized_feature_name]
+    if value == 'per_user'
+      value = AbstractFeatureBranch.user_features_storage.sismember("#{AbstractFeatureBranch::ENV_FEATURE_PREFIX}#{normalized_feature_name}", user_id)
+    end
+    value
   end
 
   raise 'Abstract feature branch conflicts with another Ruby library' if Object.new.respond_to?(:feature_branch)

--- a/spec/ext/feature_branch__feature_enabled_spec.rb
+++ b/spec/ext/feature_branch__feature_enabled_spec.rb
@@ -65,7 +65,30 @@ describe 'feature_branch object extensions' do
       feature_enabled?(:feature4a).should be_nil
       feature_enabled?(:feature5).should be_nil
     end
-
+    context 'per user' do
+      let(:user_id) { 'email1@example.com' }
+      let(:another_user_id) { 'another_email@example.com' }
+      before do
+        AbstractFeatureBranch.user_features_storage.del("#{AbstractFeatureBranch::ENV_FEATURE_PREFIX}feature6")
+      end
+      after do
+        AbstractFeatureBranch.user_features_storage.del("#{AbstractFeatureBranch::ENV_FEATURE_PREFIX}feature6")
+      end
+      it 'behaves as expected if member list is empty, regardless of the user provided' do
+        feature_enabled?('feature6').should == false
+        feature_enabled?('feature6', nil).should == false
+        feature_enabled?('feature6', user_id).should == false
+      end
+      it 'behaves as expected if member list is not empty, and user provided is in member list' do
+        AbstractFeatureBranch.toggle_features_for_user(user_id, :feature6 => true)
+        feature_enabled?('feature6').should == false
+        feature_enabled?('feature6', user_id).should == true
+      end
+      it 'behaves as expected if member list is not empty, and user provided is not in member list' do
+        AbstractFeatureBranch.toggle_features_for_user(another_user_id, :feature6 => true)
+        feature_enabled?('feature6', user_id).should == false
+      end
+    end
     context 'cacheability' do
       before do
         @development_application_root = File.expand_path(File.join(__FILE__, '..', '..', 'fixtures', 'application_development_config'))


### PR DESCRIPTION
adds "per_user" setting for features.yml and updates the feature_enabled? method: If feature is "true", feature_enabled? returns true. If feature is "false", feature_enabled? returns false. If feature is "per_user", feature_enabled? checks if the user is stored in the redis db. Updates specs to cover these additional use cases.
